### PR TITLE
fix url in README

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ biblatex.
 
 ================================================================
 The current development is available at github:
-https://github.com/marcodaniel/mdframed
+https://github.com/marcodaniel/trad-biblatex
 
 ================================================================
 Copyright (c) 2012 Marco Daniel


### PR DESCRIPTION
Looks like a copy-paste error in the url to this repo, which caused me
some minor confusion. :)
